### PR TITLE
px4io MIXER_FAIL

### DIFF
--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -116,7 +116,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		*rssi = st24_rssi;
 		r_raw_rc_count = st24_channel_count;
 
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_ST24;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_ST24);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 	}
@@ -141,7 +141,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		/* not setting RSSI since SUMD does not provide one */
 		r_raw_rc_count = sumd_channel_count;
 
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 
 		if (sumd_failsafe_state) {
@@ -233,15 +233,15 @@ controls_tick()
 	(void)dsm_port_input(&rssi, &dsm_updated, &st24_updated, &sumd_updated);
 
 	if (dsm_updated) {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_DSM;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_DSM);
 	}
 
 	if (st24_updated) {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_ST24;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_ST24);
 	}
 
 	if (sumd_updated) {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD);
 	}
 
 	perf_end(c_gather_dsm);
@@ -253,7 +253,7 @@ controls_tick()
 				       PX4IO_RC_INPUT_CHANNELS);
 
 	if (sbus_updated) {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SBUS;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SBUS);
 
 		unsigned sbus_rssi = RC_INPUT_RSSI_MAX;
 
@@ -291,7 +291,7 @@ controls_tick()
 
 	if (ppm_updated) {
 
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_PPM;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_PPM);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 	}
@@ -424,7 +424,7 @@ controls_tick()
 		}
 
 		/* set RC OK flag, as we got an update */
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_OK;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_OK);
 		r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_RC_OK;
 
 		/* if we have enough channels (5) to control the vehicle, the mapping is ok */
@@ -449,10 +449,10 @@ controls_tick()
 		rc_input_lost = true;
 
 		/* clear the input-kind flags here */
-		r_status_flags &= ~(
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(
 					  PX4IO_P_STATUS_FLAGS_RC_PPM |
 					  PX4IO_P_STATUS_FLAGS_RC_DSM |
-					  PX4IO_P_STATUS_FLAGS_RC_SBUS);
+					  PX4IO_P_STATUS_FLAGS_RC_SBUS));
 
 	}
 
@@ -462,15 +462,15 @@ controls_tick()
 
 	/* if we are in failsafe, clear the override flag */
 	if (r_raw_rc_flags & PX4IO_P_RAW_RC_FLAGS_FAILSAFE) {
-		r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE);
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE));
 	}
 
 	/* this kicks in if the receiver is gone, but there is not on failsafe (indicated by separate flag) */
 	if (rc_input_lost) {
 		/* Clear the RC input status flag, clear manual override flag */
-		r_status_flags &= ~(
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(
 					  PX4IO_P_STATUS_FLAGS_OVERRIDE |
-					  PX4IO_P_STATUS_FLAGS_RC_OK);
+					  PX4IO_P_STATUS_FLAGS_RC_OK));
 
 		/* flag raw RC as lost */
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_RC_OK);
@@ -482,7 +482,7 @@ controls_tick()
 		r_raw_rc_count = 0;
 
 		/* Set the RC_LOST alarm */
-		r_status_alarms |= PX4IO_P_STATUS_ALARMS_RC_LOST;
+		PX4_CRITICAL_SECTION(r_status_alarms |= PX4IO_P_STATUS_ALARMS_RC_LOST);
 	}
 
 	/*
@@ -525,14 +525,14 @@ controls_tick()
 		}
 
 		if (override) {
-			r_status_flags |= PX4IO_P_STATUS_FLAGS_OVERRIDE;
+			PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_OVERRIDE);
 
 		} else {
-			r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE);
+			PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE));
 		}
 
 	} else {
-		r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE);
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OVERRIDE));
 	}
 }
 

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -129,14 +129,14 @@ mixer_tick(void)
 			isr_debug(1, "AP RX timeout");
 		}
 
-		r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_FMU_OK);
-		r_status_alarms |= PX4IO_P_STATUS_ALARMS_FMU_LOST;
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_FMU_OK));
+		PX4_CRITICAL_SECTION(r_status_alarms |= PX4IO_P_STATUS_ALARMS_FMU_LOST);
 
 	} else {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_FMU_OK;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_FMU_OK);
 
 		/* this flag is never cleared once OK */
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_FMU_INITIALIZED;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_FMU_INITIALIZED);
 
 		if (system_state.fmu_data_received_time > last_fmu_update) {
 			new_fmu_data = true;
@@ -231,7 +231,7 @@ mixer_tick(void)
 		should_arm &&
 		/* and FMU is initialized */
 		(r_status_flags & PX4IO_P_STATUS_FLAGS_FMU_INITIALIZED)) {
-		r_setup_arming |= PX4IO_P_SETUP_ARMING_FORCE_FAILSAFE;
+		PX4_CRITICAL_SECTION(r_setup_arming |= PX4IO_P_SETUP_ARMING_FORCE_FAILSAFE);
 	}
 
 	/*
@@ -245,10 +245,10 @@ mixer_tick(void)
 	 * Set failsafe status flag depending on mixing source
 	 */
 	if (source == MIX_FAILSAFE) {
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_FAILSAFE;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_FAILSAFE);
 
 	} else {
-		r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_FAILSAFE);
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_FAILSAFE));
 	}
 
 	/*
@@ -336,14 +336,14 @@ mixer_tick(void)
 		/* need to arm, but not armed */
 		up_pwm_servo_arm(true);
 		mixer_servos_armed = true;
-		r_status_flags |= PX4IO_P_STATUS_FLAGS_OUTPUTS_ARMED;
+		PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_OUTPUTS_ARMED);
 		isr_debug(5, "> PWM enabled");
 
 	} else if (!needs_to_arm && mixer_servos_armed) {
 		/* armed but need to disarm */
 		up_pwm_servo_arm(false);
 		mixer_servos_armed = false;
-		r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OUTPUTS_ARMED);
+		PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_OUTPUTS_ARMED));
 		isr_debug(5, "> PWM disabled");
 	}
 
@@ -501,7 +501,7 @@ mixer_handle_text(const void *buffer, size_t length)
 	}
 
 	/* disable mixing, will be enabled once load is complete */
-	r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_MIXER_OK);
+	PX4_CRITICAL_SECTION(r_status_flags &= ~(PX4IO_P_STATUS_FLAGS_MIXER_OK));
 
 	/* abort if we're in the mixer - the caller is expected to retry */
 	if (in_mixer) {
@@ -532,7 +532,7 @@ mixer_handle_text(const void *buffer, size_t length)
 
 		/* check for overflow - this would be really fatal */
 		if ((mixer_text_length + text_length + 1) > sizeof(mixer_text)) {
-			r_status_flags &= ~PX4IO_P_STATUS_FLAGS_MIXER_OK;
+			PX4_CRITICAL_SECTION(r_status_flags &= ~PX4IO_P_STATUS_FLAGS_MIXER_OK);
 			return 0;
 		}
 

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -201,6 +201,8 @@ extern pwm_limit_t pwm_limit;
 
 #define CONTROL_PAGE_INDEX(_group, _channel) (_group * PX4IO_CONTROL_CHANNELS + _channel)
 
+#define PX4_CRITICAL_SECTION(cmd)	{ irqstate_t flags = px4_enter_critical_section(); cmd; px4_leave_critical_section(flags); }
+
 /*
  * Mixer
  */

--- a/src/modules/px4iofirmware/safety.c
+++ b/src/modules/px4iofirmware/safety.c
@@ -117,7 +117,7 @@ safety_check_button(void *arg)
 
 		} else if (counter == ARM_COUNTER_THRESHOLD) {
 			/* switch to armed state */
-			r_status_flags |= PX4IO_P_STATUS_FLAGS_SAFETY_OFF;
+			PX4_CRITICAL_SECTION(r_status_flags |= PX4IO_P_STATUS_FLAGS_SAFETY_OFF);
 			counter++;
 		}
 
@@ -128,7 +128,7 @@ safety_check_button(void *arg)
 
 		} else if (counter == ARM_COUNTER_THRESHOLD) {
 			/* change to disarmed state and notify the FMU */
-			r_status_flags &= ~PX4IO_P_STATUS_FLAGS_SAFETY_OFF;
+			PX4_CRITICAL_SECTION(r_status_flags &= ~PX4IO_P_STATUS_FLAGS_SAFETY_OFF);
 			counter++;
 		}
 


### PR DESCRIPTION
After doing several power cycle tests with a PX4 v2 hardware I noticed that my multicopter didn't arm after each 10th to 100th cycle. This is because of a MIXER_FAIL failure in the px4io module:

```nsh>
px4io status
px4io status
WARN  [px4io] loaded
protocol 4 hardware 2 bootloader 3 buffer 64B crc 0x57147223
8 controls 8 actuators 18 R/C inputs 2 analog inputs 0 relays
456 bytes free
status 0x3e4d OUTPUTS_ARMED SAFETY_OFF RC_OK PPM FMU_OK MIXER_FAIL ARM_SYNC INIT_OK FAILSAFE
alarms 0x0000
vservo 1225 mV vservo scale 10000
vrssi 1594
actuators -16666 -16666 -16666 -16666 -16666 -16666 -16666 -16666
servos 900 900 900 900 900 500 900 500
reversed outputs: [________] trims: r:   0.0000 p:   0.0000 y:   0.0000
8 raw R/C inputs 1808 1509 1509 1510 1509 1908 1508 1508
R/C flags: 0x0018 MAPPING_OK
RC data (PPM frame len) 20002 us
mapped R/C inputs 0x000f 0:0 1:0 2:0 3:8772
ADC inputs 507 2016
features 0x0008 RSSI_ADC
arming 0x043b FMU_ARMED IO_ARM_OK FAILSAFE_CUSTOM INAIR_RESTART_OK ALWAYS_PWM_ENABLE OVERRIDE_IMMEDIATE
rates 0x00ff default 50 alt 400 sbus 72
debuglevel 0
controls 0: 5 303 -265 9000 0 0 0 10000
controls 1: 0 0 0 0 0 0 0 0
controls 2: 0 0 0 0 0 0 0 0
controls 3: 0 0 0 8771 0 0 0 0
input 0 min 1105 center 1105 max 1905 deadzone 10 assigned 3 options 0x0001 ENABLED
input 1 min 1106 center 1506 max 1906 deadzone 10 assigned 0 options 0x0003 ENABLED REVERSED
input 2 min 1105 center 1504 max 1905 deadzone 10 assigned 1 options 0x0001 ENABLED
input 3 min 1106 center 1502 max 1906 deadzone 10 assigned 2 options 0x0003 ENABLED REVERSED
input 4 min 1105 center 1505 max 1906 deadzone 10 assigned 100 options 0x0001 ENABLED
input 5 min 1105 center 1505 max 1906 deadzone 10 assigned 255 options 0x0000
input 6 min 1105 center 1505 max 1906 deadzone 10 assigned 255 options 0x0000
input 7 min 1105 center 1505 max 1906 deadzone 10 assigned 255 options 0x0000
input 8 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 9 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 10 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 11 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 12 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 13 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 14 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 15 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 16 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
input 17 min 1000 center 1500 max 2000 deadzone 0 assigned 255 options 0x0000
failsafe 500 500 500 500 500 500 500 500
disarmed values 900 900 900 900 900 900 900 900
```
The reason why this occur is because of a read-modify-write bug in the px4io firmware:
- In the files controls.c, mixer.cpp and safety.c the variable r_status_flags get modified by |= or &= which are not atomic operations.
- parallel to this the fmu can modify this variable via an interrupt routine in the px4io firmware
Thus the new r_status_flags can be back overwritten by the old value.

To solve this problem I suggest a macro with the px4_enter_critical_section and px4_leave_critical_section for the |= and &= operations (only for controls.c, mixer.cpp and safety.c).